### PR TITLE
require('Primus') should be require('primus')

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ exports.createConnection = createConnection;
 
 var duplex = require('duplex');
 var debug = require('debug')('strong-pubsub-primus');
-var Primus = require('Primus');
+var Primus = require('primus');
 var util = require('util');
 
 function createConnection(port, host, options) {


### PR DESCRIPTION
Allowing it to be found on all environments.